### PR TITLE
Implement sent context trim on autocomplete

### DIFF
--- a/src/L.AI.Options/GeneralOptions.cs
+++ b/src/L.AI.Options/GeneralOptions.cs
@@ -74,6 +74,20 @@ namespace L_AI.Options
         [Description("Only used if impossible to get context length from the API.")]
         public int ContextLength { get; set; } = 4096;
 
+
+        //
+        // Limited autocomplete context parameters
+        //
+        [Category("Autocomplete parameters")]
+        [DisplayName("Limit code context")]
+        [Description("Execute autocomplete with a limited context length.")]
+        public bool LimitAutocompleteContext { get; set; } = false;
+
+        [Category("Autocomplete parameters")]
+        [DisplayName("Limited code context length")]
+        [Description("Limited code context length, applied when limited code context is true.")]
+        public int LimitedContextLength { get; set; } = 100;
+
         //
         //      Suggestions Settings
         //


### PR DESCRIPTION
Implemented an optional context trim setting. If set to true, the code is trimmed before being sent to the LLM.

It seems to work fine when autocomplete is used. But for manual complete I have noticed that the code is sent to the LLM correctly, but a suggestion does not appear. I was unable to figure out if my implementation broke manual complete or if it is my local issue.

Could you test it out before merging and provide insight?